### PR TITLE
Allow customizing styles via a custom class

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -79,6 +79,7 @@ class EditorPreview(object):
             bodyclass = theme_manager.body_classes_for_card_ord(c.ord, mw.pm.night_mode())
         else:
             bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
+        bodyclass += " editor-preview"
 
         return f"_showAnswer({json.dumps(a)},'{bodyclass}');"
 


### PR DESCRIPTION
Previewer-specific styles can now be specified in card templates by targeting the "editor-preview" class. E.g:
```
.editor-preview {
  font-size: 12px;
}
```

Closes #1