### PR TITLE
Remove the usage of deprecated function to fix the dark mode.

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -82,10 +82,7 @@ class EditorPreview(object):
         c = note.ephemeral_card()
         a = mw.prepare_card_text_for_display(c.answer())
         a = gui_hooks.card_will_show(a, c, "clayoutAnswer")
-        if theme_manager.night_mode:
-            bodyclass = theme_manager.body_classes_for_card_ord(c.ord, mw.pm.night_mode())
-        else:
-            bodyclass = theme_manager.body_classes_for_card_ord(c.ord)
+        bodyclass = theme_manager.body_classes_for_card_ord(c.ord, theme_manager.night_mode)
         bodyclass += " editor-preview"
 
         return f"_showAnswer({json.dumps(a)},'{bodyclass}');"


### PR DESCRIPTION
The function mv.pm.night_mode() is [deprecated](https://github.com/ankitects/anki/blob/1ed2cce648ee3168ca97e005b993a2953cdb7536/qt/aqt/profiles.py#L537). 

Furthermore, on my machine (Anki version ⁨2.1.54, Python 3.9.10 Qt 6.3.1 PyQt 6.3.1, Ubuntu 22.04.1 LTS), this function returns false, even when both the dark mode in anki and dark theme in the system are set.

This basically reverts #5, which I do not really understand. (when theme_manager.body_classes_for_card_ord is called with just one argument, theme_manager.night_mode is [used](https://github.com/ankitects/anki/blob/627313666e27f32d14ee1b96ad63f6bc4eaa03ad/qt/aqt/theme.py#L153) later anyways.

I believe this has something to do with #9.
