### PR TITLE
Fix Qt enums incompatibility with Anki v23.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.idea
 
 # Spyder project settings
 .spyderproject

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -56,22 +56,22 @@ class EditorPreview(object):
         location = config["location"]
         split = QSplitter()
         if location == "above":
-            split.setOrientation(Qt.Vertical)
+            split.setOrientation(Qt.Orientation.Vertical)
             split.addWidget(editor.editor_preview)
             split.addWidget(editor.web)
             sizes = [editorR, mainR]
         elif location == "below":
-            split.setOrientation(Qt.Vertical)
+            split.setOrientation(Qt.Orientation.Vertical)
             split.addWidget(editor.web)
             split.addWidget(editor.editor_preview)
             sizes = [mainR, editorR]
         elif location == "left":
-            split.setOrientation(Qt.Horizontal)
+            split.setOrientation(Qt.Orientation.Horizontal)
             split.addWidget(editor.editor_preview)
             split.addWidget(editor.web)
             sizes = [editorR, mainR]
         elif location == "right":
-            split.setOrientation(Qt.Horizontal)
+            split.setOrientation(Qt.Orientation.Horizontal)
             split.addWidget(editor.web)
             split.addWidget(editor.editor_preview)
             sizes = [mainR, editorR]


### PR DESCRIPTION
Here we update enums usage for Qt6, since new Anki version(23.10) dropped compatibility for Qt5.
More details on migration to Qt6 here: https://forums.ankiweb.net/t/porting-tips-for-anki-23-10/35916#enumerations-6

**Fixes:** #19 